### PR TITLE
A temporary fix for Wstringop-overflow warning

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -49,7 +49,10 @@ cd ..
 
 cd fdkaac-1.0.2
 autoreconf -i
-CC="gcc -pipe -static-libgcc" CXX="g++ -pipe -static-libgcc" ./configure --prefix=$MINGW_PREFIX/$MINGW_CHOST/ CFLAGS="${CFLAGS}"
+#'-Wstringop-overflow=0' is a temporary fix for
+#'src/pcm_readhelper.c:231:24: warning: writing 1 byte into a region of size 0 [-Wstringop-overflow=]';
+#Remove this param if upstream fix this problem.
+CC="gcc -pipe -static-libgcc -Wstringop-overflow=0" CXX="g++ -pipe -static-libgcc" ./configure --prefix=$MINGW_PREFIX/$MINGW_CHOST/ CFLAGS="${CFLAGS}"
 make -j$NPB
 make install
 cd ..


### PR DESCRIPTION
This is a temporary solution for `src/pcm_readhelper.c:231:24: warning: writing 1 byte into a region of size 0 [-Wstringop-overflow=]` during compiling [fdkaac](https://github.com/nu774/fdkaac/) using GCC 10.

This PR **does not affect the results of the compilation, nor does it fix the problem in the upstream source code**. 

However the warning seems to be harmless but annoying, so we can disabled it until upstream fix the problem.

More info about this upstream bug can be seen in https://github.com/nu774/fdkaac/issues/46.