### PR TITLE
Update fdkaac 1.0.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # libfdk-aac for Windows binary builder
 
-libfdk-aac (0.1.6 and 2.0.2) and fdkaac tool (1.0.2) for Windows auto binary builder scripts.
+libfdk-aac (0.1.6 and 2.0.2) and fdkaac tool (1.0.3) for Windows auto binary builder scripts.
 
 [![CI build (master)](https://github.com/kekyo/fdk-aac-win32-builder/workflows/Build/badge.svg?branch=master)](https://github.com/kekyo/fdk-aac-win32-builder/actions?query=branch%3Amaster)
 
-[fdk-aac](https://github.com/mstorsjo/fdk-aac) is "A standalone library of the Fraunhofer FDK AAC code from Android."
+[fdk-aac](https://github.com/mstorsjo/fdk-aac) is "A standalone library of the Fraunhofer FDK AAC code from Android." A mirror of released source code, see [official opencore-amr project](https://sourceforge.net/projects/opencore-amr/).
 
 [fdkaac](https://github.com/nu774/fdkaac) is "command line encoder frontend for libfdk-aac".
 
@@ -28,8 +28,8 @@ It'll build both:
 4. Install development tools.
   * Execute `pacman -S mingw-w64-i686-gcc autoconf automake-wrapper make libtool` if you wanna 32bit binary.
   * Execute `pacman -S mingw-w64-x86_64-gcc autoconf automake-wrapper make libtool` if you wanna 64bit binary.
-5. Execute `./setup.sh`, it'll download fdk-aac archive from [official opencore-amr project](https://sourceforge.net/projects/opencore-amr/) mirror, and extract reference files for testing purpose.
-6. You can choose GCC's optimization option. See `CFLAGS` symbols in the head of `build.sh` file.
+5. Execute `./setup.sh`, it'll download source code archive and extract reference files for testing purpose.
+6. You can choose GCC's optimization option by editing `build.sh`. See `CFLAGS` symbols in the head of this file.
 7. Execute `./build.sh`.
 
 Finally, stored binaries into artifacts directory.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # libfdk-aac for Windows binary builder
 
-libfdk-aac (0.1.6 and 2.0.2) and fdkaac tool (1.0.2) for Windows auto binary builder scripts.
+libfdk-aac (0.1.6 and 2.0.2) and fdkaac tool (1.0.3) for Windows auto binary builder scripts.
 
 [![CI build (master)](https://github.com/kekyo/fdk-aac-win32-builder/workflows/Build/badge.svg?branch=master)](https://github.com/kekyo/fdk-aac-win32-builder/actions?query=branch%3Amaster)
 

--- a/build.sh
+++ b/build.sh
@@ -33,7 +33,7 @@ cd $MINGW_CHOST
 
 tar -zxf ../../artifacts/fdk-aac-0.1.6.tar.gz
 tar -zxf ../../artifacts/fdk-aac-2.0.2.tar.gz
-tar -zxf ../../artifacts/fdkaac-1.0.2.tar.gz
+tar -zxf ../../artifacts/fdkaac-1.0.3.tar.gz
 
 cd fdk-aac-0.1.6
 #Temporary add "-flto" option here, should be replaced by interactive compile switches in the future
@@ -50,7 +50,7 @@ make -j$NPB
 make install
 cd ..
 
-cd fdkaac-1.0.2
+cd fdkaac-1.0.3
 autoreconf -i
 CC="gcc -pipe -static-libgcc" CXX="g++ -pipe -static-libgcc" ./configure --prefix=$MINGW_PREFIX/$MINGW_CHOST/ CFLAGS="${CFLAGS}"
 make -j$NPB
@@ -71,4 +71,4 @@ cp ../../stage/$MINGW_CHOST/fdk-aac-2.0.2/.libs/libfdk-aac.a libfdk-aac-2.a
 cp ../../stage/$MINGW_CHOST/fdk-aac-2.0.2/.libs/libfdk-aac.dll.a libfdk-aac-2.dll.a
 cp ../../stage/$MINGW_CHOST/fdk-aac-2.0.2/.libs/libfdk-aac-2.dll .
 
-cp ../../stage/$MINGW_CHOST/fdkaac-1.0.2/fdkaac.exe .
+cp ../../stage/$MINGW_CHOST/fdkaac-1.0.3/fdkaac.exe .

--- a/setup.sh
+++ b/setup.sh
@@ -14,18 +14,9 @@ mkdir stage
 
 cd artifacts
 
-# wget https://jaist.dl.sourceforge.net/project/opencore-amr/fdk-aac/fdk-aac-0.1.6.tar.gz
-# wget https://jaist.dl.sourceforge.net/project/opencore-amr/fdk-aac/fdk-aac-2.0.1.tar.gz
-## wget https://jaist.dl.sourceforge.net/project/opencore-amr/fdk-aac/fdk-aac-2.0.2.tar.gz
-## wget https://github.com/nu774/fdkaac/archive/1.0.0.tar.gz
-# wget https://github.com/nu774/fdkaac/archive/refs/tags/v1.0.2.tar.gz
-
-# mv 1.0.0.tar.gz fdkaac-1.0.0.tar.gz
-
 wget https://github.com/kekyo/fdk-aac-win32-builder/releases/download/distributes/fdk-aac-0.1.6.tar.gz
-#wget https://github.com/kekyo/fdk-aac-win32-builder/releases/download/distributes/fdk-aac-2.0.1.tar.gz
 wget https://github.com/kekyo/fdk-aac-win32-builder/releases/download/distributes/fdk-aac-2.0.2.tar.gz
-#wget https://github.com/kekyo/fdk-aac-win32-builder/releases/download/distributes/fdkaac-1.0.0.tar.gz
-wget https://github.com/kekyo/fdk-aac-win32-builder/releases/download/distributes/fdkaac-1.0.2.tar.gz
+#wget https://github.com/kekyo/fdk-aac-win32-builder/releases/download/distributes/fdkaac-1.0.2.tar.gz
+wget https://github.com/kekyo/fdk-aac-win32-builder/releases/download/distributes/fdkaac-1.0.3.tar.gz
 
 cd ..


### PR DESCRIPTION
Just a regular commit for upstream release update: fdkaac 1.0.3 released.
https://github.com/nu774/fdkaac/blob/cdfb81d7c6c00dea37a1794a7e021a7753c8d013/ChangeLog#L1-L7

Since the necessity of testing is not obvious and new reference files need to be manually generated for each release, test scripts can be deleted.

TODO:
- [x] 1. Upload fdkaac 1.0.3 source code package into https://github.com/kekyo/fdk-aac-win32-builder/releases/tag/distributes
- [x] 2. Verity the script using new fdkaac

~~3. Upload new test-materials~~
- [ ] 3. OR disabling `test.sh`